### PR TITLE
fix/Adds missing applicaiton of the prettier config

### DIFF
--- a/.yo-rc.json
+++ b/.yo-rc.json
@@ -1,0 +1,5 @@
+{
+    "generator-jestr": {
+        "prettierConfigPath": ".prettierrc.js"
+    }
+}

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -98,8 +98,7 @@ module.exports = class extends Generator {
             path.join(this.contextRoot, destinationFileName),
             this.inputArgs
         )
-        // TODO: Add in yo-rc.json to say where the prettier rc file can be found, and load those if exist
-        this.queueTransformStream(prettier())
+        this.queueTransformStream(prettier(this.prettierConfig))
     }
 
     _getTemplateFileName() {


### PR DESCRIPTION
- The prettier config application was omitted after having been read. This fixes that.
- Also stores the .yo-rc.json defaults created by running the generator.